### PR TITLE
[INJIMOB-3711] - Update configuration to publish artifact to io.inji group

### DIFF
--- a/.github/workflows/kotlin-artifacts-build.yml
+++ b/.github/workflows/kotlin-artifacts-build.yml
@@ -8,7 +8,6 @@ on:
         required: false
         default: 'Triggered for inji-vc-renderer Updates'
         type: string
-
       release_type:
         description: 'Select release type to publish: snapshot or release'
         required: true
@@ -17,12 +16,19 @@ on:
         options:
           - snapshot
           - release
-
       publication_type:
         description: 'Select artifact type to publish: aar, jar, or both (only for release)'
         required: true
         default: both
         type: string
+      group_path:
+        description: 'Select Maven group path'
+        required: true
+        type: choice
+        default: io/inji
+        options:
+          - io/inji
+          - io/mosip
 
 jobs:
   publish-snapshot:
@@ -31,6 +37,7 @@ jobs:
     with:
       SERVICE_LOCATION: 'kotlin'
       ANDROID_SERVICE_LOCATION: 'injivcrenderer'
+      GROUP_PATH: ${{ inputs.group_path }}
       JAVA_VERSION: 21
       LICENSE_NAME: 'MPL-2.0'
       RELEASE_TYPE: ${{ inputs.release_type }}
@@ -48,6 +55,7 @@ jobs:
     with:
       SERVICE_LOCATION: 'kotlin'
       ANDROID_SERVICE_LOCATION: 'injivcrenderer'
+      GROUP_PATH: ${{ inputs.group_path }}
       JAVA_VERSION: 21
       LICENSE_NAME: 'MPL-2.0'
       RELEASE_TYPE: ${{ inputs.release_type }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced artifact publishing workflow with configurable group path selection, enabling flexible deployment options for artifact distribution processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->